### PR TITLE
Add DotMatch for CRISPR guide-capture assignment

### DIFF
--- a/database/categories-idx.tsv
+++ b/database/categories-idx.tsv
@@ -770,6 +770,7 @@ DistMap	Classification
 DistMap	Visualisation
 Domino	GeneNetworks
 Domino	Visualisation
+DotMatch	Perturbations
 DoubletCollection	Clustering
 DoubletCollection	QualityControl
 DoubletCollection	Visualisation

--- a/database/repositories.tsv
+++ b/database/repositories.tsv
@@ -318,6 +318,7 @@ DigitalCellSorter	NA	NA	DigitalCellSorter	NA	sdomanskyi/DigitalCellSorter
 Dino	Dino	NA	NA	NA	JBrownBiostat/Dino
 DistMap	NA	NA	NA	NA	rajewsky-lab/distmap
 Domino	NA	NA	NA	NA	chris-cherry/domino
+DotMatch	NA	NA	dotmatch	dotmatch	dnncha/dotmatch
 DoubletCollection	NA	NA	NA	NA	xnnba1984/DoubletCollection
 DoubletDecon	NA	NA	NA	NA	EDePasquale/DoubletDecon
 DoubletDetection	NA	NA	doubletdetection	NA	JonathanShor/DoubletDetection

--- a/database/tools.tsv
+++ b/database/tools.tsv
@@ -318,6 +318,7 @@ DigitalCellSorter	Python	https://github.com/sdomanskyi/DigitalCellSorter	Identif
 Dino	R	https://github.com/JBrownBiostat/Dino	Dino constructs a flexible negative-binomial mixture model of gene expression for normalisation	GPL-3.0	2020-11-08	2021-10-29
 DistMap	R	https://github.com/rajewsky-lab/distmap	DistMap can be used to spatially map single cell RNA sequencing data by using an existing reference database of in situs.	MIT	2017-09-01	2017-09-01
 Domino	R	https://github.com/chris-cherry/domino	Domino is a tool for analysis of intra- and intercellular signaling in single cell RNA seq based on transcription factor activation	GPL-3.0	2020-07-31	2021-08-11
+DotMatch	Python	https://github.com/dnncha/dotmatch	DotMatch assigns fixed read windows to known CRISPR guides and feature barcodes for guide-capture and perturb-seq workflows.	Apache-2.0	2026-08-22	2026-08-22
 DoubletCollection	R	https://github.com/xnnba1984/DoubletCollection	DoubletCollection is an R package that integrates the installation, execution and benchmark of eight cutting-edge computational doublet-detection methods	GPL-3.0	2022-10-14	2022-10-14
 DoubletDecon	R	https://github.com/EDePasquale/DoubletDecon	A cell-state aware tool for removing doublets from single-cell RNA-seq data.	MIT	2018-07-28	2020-08-20
 DoubletDetection	Python	https://github.com/JonathanShor/DoubletDetection	DoubletDetection is a Python3 package to detect doublets (technical errors) in single-cell RNA-seq count matrices.	MIT	2018-05-13	2021-01-08


### PR DESCRIPTION
Follow-up to #308.

This adds a minimal DotMatch record to the database:

- `database/tools.tsv`: Python tool, Apache-2.0, repository, and a narrow description;
- `database/repositories.tsv`: PyPI, Conda, and GitHub identifiers;
- `database/categories-idx.tsv`: `Perturbations`.

The intended use here is fixed read-window assignment to known CRISPR guides or feature barcodes before downstream single-cell analysis. DotMatch is not being presented as a UMI counter, cell caller, or complete single-cell pipeline.

Public references:
- Documentation: https://dotmatch.readthedocs.io/en/latest/tutorials/scverse-perturb-seq.html
- PyPI: https://pypi.org/project/dotmatch/
- Bioconda: https://anaconda.org/bioconda/dotmatch

Validation: TSV field counts, alphabetical placement, and `git diff --check` pass.